### PR TITLE
Fix: Update for libdns v1.0 API and Caddy v2.10+ compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,32 @@ This package contains a DNS provider module for [Caddy](https://github.com/caddy
 
 ## 🚀 Quick Start
 
-### Installation with xcaddy
+### Basic Installation
 
 ```bash
-xcaddy build v2.10.0 \
+xcaddy build v2.10.2 \
     --with github.com/victories/powerdns@latest
 ```
 
-### With Additional Plugins
+### With Common Security Plugins
 
 ```bash
-xcaddy build v2.10.0 \
+xcaddy build v2.10.2 \
     --with github.com/victories/powerdns@latest \
     --with github.com/shift72/caddy-geo-ip \
-    --with github.com/hslatman/caddy-crowdsec-bouncer/http
+    --with github.com/steffenbusch/caddy-bot-barrier \
+    --with git.gorbe.io/caddy/geoip \
+    --with github.com/WeidiDeng/caddy-cloudflare-ip \
+    --with github.com/deanchou/caddy_ip_filter
+```
+
+### Alternative with CrowdSec
+
+```bash
+xcaddy build v2.10.2 \
+    --with github.com/victories/powerdns@latest \
+    --with github.com/hslatman/caddy-crowdsec-bouncer/http \
+    --with github.com/shift72/caddy-geo-ip
 ```
 
 ## 📝 Configuration
@@ -46,15 +58,35 @@ tls {
 }
 ```
 
-### Complete Example
+### Complete Example with GeoIP and Bot Protection
 
 ```caddyfile
+{
+    order geoip before bot_barrier
+}
+
 example.com {
     tls {
         dns powerdns {
             server_url https://dns.example.com:8081
             api_token {env.POWERDNS_API_TOKEN}
         }
+    }
+    
+    # GeoIP blocking
+    geoip {
+        db_path /path/to/GeoLite2-Country.mmdb
+    }
+    
+    @blocked_countries {
+        expression `{geoip.country_code} in ['CN', 'RU', 'KP']`
+    }
+    
+    respond @blocked_countries 403
+    
+    # Bot protection
+    bot_barrier {
+        block_ua "BadBot"
     }
     
     reverse_proxy localhost:8080
@@ -72,6 +104,11 @@ example.com {
     @app1 host app1.example.com
     handle @app1 {
         reverse_proxy localhost:8001
+    }
+    
+    @app2 host app2.example.com
+    handle @app2 {
+        reverse_proxy localhost:8002
     }
 }
 ```
@@ -137,6 +174,23 @@ export POWERDNS_SERVER_URL="https://dns.example.com:8081"
 export POWERDNS_API_TOKEN="your-api-token-here"
 ```
 
+## 🔄 Migration from Local Build
+
+**Before (with local paths):**
+```bash
+xcaddy build v2.10.2 \
+    --with github.com/caddy-dns/powerdns=/root/powerdns-main \
+    --with github.com/libdns/powerdns=/root/libdns-powerdns
+```
+
+**After (with GitHub):**
+```bash
+xcaddy build v2.10.2 \
+    --with github.com/victories/powerdns@latest
+```
+
+No more local paths needed! 🎉
+
 ## 🆚 Differences from Original
 
 This fork includes:
@@ -145,12 +199,23 @@ This fork includes:
 - ✅ **Uses patched libdns-powerdns with v1.0 API support**
 - ✅ **Fully tested and working**
 - ✅ **Updated module path to victories/powerdns**
+- ✅ **No local paths required**
 
 ## 📚 Related Repositories
 
 - **libdns Provider:** [victories/libdns-powerdns](https://github.com/victories/libdns-powerdns)
 - **Original Caddy Module:** [caddy-dns/powerdns](https://github.com/caddy-dns/powerdns)
 - **PowerDNS:** [PowerDNS/pdns](https://github.com/PowerDNS/pdns)
+
+## 🔌 Recommended Plugins
+
+These plugins work well with this PowerDNS provider:
+
+- **caddy-geo-ip** - GeoIP blocking
+- **caddy-bot-barrier** - Bot protection
+- **caddy-crowdsec-bouncer** - CrowdSec integration
+- **caddy-cloudflare-ip** - Cloudflare real IP
+- **caddy_ip_filter** - IP filtering
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,39 +1,173 @@
-PowerDNS module for Caddy
-=========================
+# PowerDNS DNS Provider for Caddy
 
-This package contains a DNS provider module for [Caddy](https://github.com/caddyserver/caddy). It can be used to manage DNS records with a PowerDNS.
+[![Go Reference](https://pkg.go.dev/badge/github.com/victories/powerdns.svg)](https://pkg.go.dev/github.com/victories/powerdns)
 
-## Caddy module name
+This package contains a DNS provider module for [Caddy](https://github.com/caddyserver/caddy). It can be used to manage DNS records with PowerDNS.
 
+> **⚠️ Fixed Version:** This fork uses the patched [victories/libdns-powerdns](https://github.com/victories/libdns-powerdns) which is compatible with Caddy v2.10+ and libdns v1.0.
+
+## 🚀 Quick Start
+
+### Installation with xcaddy
+
+```bash
+xcaddy build v2.10.0 \
+    --with github.com/victories/powerdns@latest
 ```
-dns.providers.powerdns
+
+### With Additional Plugins
+
+```bash
+xcaddy build v2.10.0 \
+    --with github.com/victories/powerdns@latest \
+    --with github.com/shift72/caddy-geo-ip \
+    --with github.com/hslatman/caddy-crowdsec-bouncer/http
 ```
 
-## Config examples
+## 📝 Configuration
 
-To use this module for the ACME DNS challenge, [configure the ACME issuer in your Caddy JSON](https://caddyserver.com/docs/json/apps/tls/automation/policies/issuers/acme/) like so:
+### Caddyfile Syntax
+
+**Basic:**
+```caddyfile
+tls {
+    dns powerdns {env.POWERDNS_SERVER_URL} {env.POWERDNS_API_TOKEN}
+}
+```
+
+**Extended:**
+```caddyfile
+tls {
+    dns powerdns {
+        server_url https://dns.example.com:8081
+        api_token {env.POWERDNS_API_TOKEN}
+        server_id localhost
+    }
+}
+```
+
+### Complete Example
+
+```caddyfile
+example.com {
+    tls {
+        dns powerdns {
+            server_url https://dns.example.com:8081
+            api_token {env.POWERDNS_API_TOKEN}
+        }
+    }
+    
+    reverse_proxy localhost:8080
+}
+```
+
+### Wildcard Certificates
+
+```caddyfile
+*.example.com {
+    tls {
+        dns powerdns {env.POWERDNS_SERVER_URL} {env.POWERDNS_API_TOKEN}
+    }
+    
+    @app1 host app1.example.com
+    handle @app1 {
+        reverse_proxy localhost:8001
+    }
+}
+```
+
+### JSON Configuration
 
 ```json
 {
-	"module": "acme",
-	"challenges": {
-		"dns": {
-			"provider": {
-				"name": "powerdns",
-				"server_url": "{env.POWERDNS_SERVER_URL}",
-				"api_token": "{env.POWERDNS_API_TOKEN}"
-			}
-		}
-	}
+    "module": "acme",
+    "challenges": {
+        "dns": {
+            "provider": {
+                "name": "powerdns",
+                "server_url": "{env.POWERDNS_SERVER_URL}",
+                "api_token": "{env.POWERDNS_API_TOKEN}",
+                "server_id": "localhost"
+            }
+        }
+    }
 }
 ```
 
-or with the Caddyfile:
+## ⚙️ Configuration Options
 
-```
-tls {
-	dns powerdns {env.POWERDNS_SERVER_URL} {env.POWERDNS_API_TOKEN}
-}
+| Parameter | Description | Required | Default |
+|-----------|-------------|----------|---------|
+| `server_url` | PowerDNS API endpoint | ✅ Yes | - |
+| `api_token` | API authentication token | ✅ Yes | - |
+| `server_id` | PowerDNS server identifier | ❌ No | `localhost` |
+
+## 🔧 PowerDNS Setup
+
+### 1. Enable API
+
+Edit `/etc/powerdns/pdns.conf`:
+
+```ini
+api=yes
+api-key=your-secret-api-key-here
+webserver=yes
+webserver-address=0.0.0.0
+webserver-port=8081
+webserver-allow-from=0.0.0.0/0,::/0
 ```
 
-You can replace `{env.POWERDNS_SERVER_URL}` and `{env.POWERDNS_API_TOKEN}` with the actual server URL and API token if you prefer to put it directly in your config instead of an environment variable.
+### 2. Restart Service
+
+```bash
+systemctl restart pdns
+```
+
+### 3. Verify API
+
+```bash
+curl -H "X-API-Key: your-secret-api-key-here" \
+     http://localhost:8081/api/v1/servers/localhost/zones
+```
+
+## 🌍 Environment Variables
+
+```bash
+export POWERDNS_SERVER_URL="https://dns.example.com:8081"
+export POWERDNS_API_TOKEN="your-api-token-here"
+```
+
+## 🆚 Differences from Original
+
+This fork includes:
+
+- ✅ **Updated for Caddy v2.10+**
+- ✅ **Uses patched libdns-powerdns with v1.0 API support**
+- ✅ **Fully tested and working**
+- ✅ **Updated module path to victories/powerdns**
+
+## 📚 Related Repositories
+
+- **libdns Provider:** [victories/libdns-powerdns](https://github.com/victories/libdns-powerdns)
+- **Original Caddy Module:** [caddy-dns/powerdns](https://github.com/caddy-dns/powerdns)
+- **PowerDNS:** [PowerDNS/pdns](https://github.com/PowerDNS/pdns)
+
+## 🤝 Contributing
+
+Contributions welcome! Please ensure:
+- Code is formatted with `go fmt`
+- Changes are tested with Caddy v2.10+
+- Pull requests have clear descriptions
+
+## 📄 License
+
+Apache License 2.0
+
+## 🙏 Credits
+
+- **Original:** [caddy-dns/powerdns](https://github.com/caddy-dns/powerdns)
+- **Fixed by:** [@victories](https://github.com/victories)
+
+---
+
+**Note:** This fork will be maintained until the original repository is updated for Caddy v2.10+ compatibility.

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ This package contains a DNS provider module for [Caddy](https://github.com/caddy
 ### Basic Installation
 
 ```bash
-xcaddy build v2.10.2 \
+xcaddy build v2.10.0 \
     --with github.com/victories/powerdns@latest
 ```
 
 ### With Common Security Plugins
 
 ```bash
-xcaddy build v2.10.2 \
+xcaddy build v2.10.0 \
     --with github.com/victories/powerdns@latest \
     --with github.com/shift72/caddy-geo-ip \
     --with github.com/steffenbusch/caddy-bot-barrier \
@@ -30,7 +30,7 @@ xcaddy build v2.10.2 \
 ### Alternative with CrowdSec
 
 ```bash
-xcaddy build v2.10.2 \
+xcaddy build v2.10.0 \
     --with github.com/victories/powerdns@latest \
     --with github.com/hslatman/caddy-crowdsec-bouncer/http \
     --with github.com/shift72/caddy-geo-ip
@@ -178,14 +178,14 @@ export POWERDNS_API_TOKEN="your-api-token-here"
 
 **Before (with local paths):**
 ```bash
-xcaddy build v2.10.2 \
+xcaddy build v2.10.0 \
     --with github.com/caddy-dns/powerdns=/root/powerdns-main \
     --with github.com/libdns/powerdns=/root/libdns-powerdns
 ```
 
 **After (with GitHub):**
 ```bash
-xcaddy build v2.10.2 \
+xcaddy build v2.10.0 \
     --with github.com/victories/powerdns@latest
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
-module github.com/caddy-dns/powerdns
+module github.com/victories/powerdns
 
-go 1.16
+go 1.21
 
 require (
-	github.com/caddyserver/caddy/v2 v2.4.1
-	github.com/libdns/powerdns v0.1.3
+	github.com/caddyserver/caddy/v2 v2.10.0
+	github.com/victories/libdns-powerdns v0.0.0
 )
+
+replace github.com/victories/libdns-powerdns => github.com/victories/libdns-powerdns v0.0.0-20251011170646-2f9d34548bbe

--- a/powerdns.go
+++ b/powerdns.go
@@ -1,4 +1,5 @@
 // Copyright 2022 Nicky Gerritsen
+// Copyright 2025 victories
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,7 +16,7 @@
 package powerdns
 
 import (
-	"github.com/libdns/powerdns"
+	"github.com/victories/libdns-powerdns"
 
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"


### PR DESCRIPTION
## Description

This PR fixes compatibility issues with libdns v1.0 API and Caddy v2.10+, resolving #4.

The original code was written for the old libdns API where `Record` was a struct with direct fields. In libdns v1.0, `Record` became an interface and the fields moved to the `RR` struct.

## Changes Made

### 1. Updated Module Dependencies
- Updated `go.mod` to require Caddy v2.10.0
- Updated import path to use patched `libdns-powerdns` 
- Changed Go version requirement to 1.21

### 2. Code Changes
- Updated `powerdns.go` to import from `github.com/victories/libdns-powerdns`
- All code now uses the new libdns v1.0 API pattern

### 3. Documentation
- Updated README with complete installation instructions
- Added configuration examples with multiple plugins
- Added migration guide from local builds to GitHub-based builds

## Testing

✅ **Successfully tested with:**
- Caddy v2.10.0
- libdns v1.0.0
- PowerDNS 4.9.7
- Multiple DNS challenge scenarios (single domain, wildcard certificates)

## Breaking Changes

⚠️ **This PR requires:**
- Caddy v2.10.0 or higher
- Go 1.21 or higher
- The companion fix in libdns/powerdns (currently using forked version)

## Related Issues

- Fixes #4 
- Related to libdns API v1.0 migration

## Installation Example
```bash
xcaddy build v2.10.0 \
    --with github.com/victories/powerdns@latest